### PR TITLE
paths for c extensions

### DIFF
--- a/ext/core/extconf.rb
+++ b/ext/core/extconf.rb
@@ -1,2 +1,2 @@
 require 'mkmf'
-create_makefile('core/core')
+create_makefile('distance_measures/core')

--- a/ext/euclidean_distance/extconf.rb
+++ b/ext/euclidean_distance/extconf.rb
@@ -1,2 +1,2 @@
 require 'mkmf'
-create_makefile('euclidean_distance/euclidean_distance')
+create_makefile('distance_measures/euclidean_distance')


### PR DESCRIPTION
Hello, I have corrected the paths that the c extensions are put. 

Without this, requiring `distance_measures` fails with a `LoadError` (no such file to load -- distance_measures/euclidean_distance).
